### PR TITLE
add-spanish-locale-default-language

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ graph TD
   class ECR,SM,S3,Bedrock services
 ```
 
-
 ---
 
 ## Tech Stack
@@ -223,7 +222,8 @@ aws secretsmanager create-secret \
 {
   "S3_BUCKET_NAME": "stori-documents",
   "EMBEDDING_MODEL": "amazon.titan-embed-text-v1",
-  "BEDROCK_MODEL_ID": "anthropic.claude-3-5-haiku-20241022-v1:0"
+  "BEDROCK_MODEL_ID": "anthropic.claude-3-5-haiku-20241022-v1:0",
+  "DEFAULT_LANGUAGE": "es"
 }
 ```
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,8 +6,12 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     gcc \
     g++ \
     curl \
+    locales \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+RUN sed -i '/es_ES.UTF-8/s/^# //g' /etc/locale.gen && \
+    locale-gen
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
@@ -19,6 +23,10 @@ RUN mkdir -p /app/chroma_db /app/logs /chroma/chroma_db
 
 ENV PYTHONPATH=/app
 ENV PYTHONUNBUFFERED=1
+
+ENV LANG=es_ES.UTF-8
+ENV LC_ALL=es_ES.UTF-8
+ENV LANGUAGE=es_ES:es
 
 EXPOSE 8000
 

--- a/infrastructure/.secrets/stori-rag-backend-template.json
+++ b/infrastructure/.secrets/stori-rag-backend-template.json
@@ -1,5 +1,6 @@
 {
   "S3_BUCKET_NAME": "stori-documents",
   "EMBEDDING_MODEL": "amazon.titan-embed-text-v1",
-  "BEDROCK_MODEL_ID": "anthropic.claude-3-5-haiku-20241022-v1:0"
+  "BEDROCK_MODEL_ID": "anthropic.claude-3-5-haiku-20241022-v1:0",
+  "DEFAULT_LANGUAGE": "es"
 }

--- a/infrastructure/infrastructure/stori_rag_stack.py
+++ b/infrastructure/infrastructure/stori_rag_stack.py
@@ -155,6 +155,9 @@ class StoriRagStack(Stack):
                     "REDIS_URL": redis_endpoint,
                     "REDIS_DB": "0",
                     "CHROMA_PERSIST_DIRECTORY": "/chroma/chroma_db",
+                    "LANG": "es_ES.UTF-8",
+                    "LC_ALL": "es_ES.UTF-8",
+                    "LANGUAGE": "es_ES:es",
                 },
                 secrets={
                     "BEDROCK_MODEL_ID": ecs.Secret.from_secrets_manager(
@@ -165,6 +168,9 @@ class StoriRagStack(Stack):
                     ),
                     "EMBEDDING_MODEL": ecs.Secret.from_secrets_manager(
                         rag_secret, "EMBEDDING_MODEL"
+                    ),
+                    "DEFAULT_LANGUAGE": ecs.Secret.from_secrets_manager(
+                        rag_secret, "DEFAULT_LANGUAGE"
                     ),
                 },
             ),


### PR DESCRIPTION
### Description

- Added Spanish locale support (es_ES.UTF-8) to the backend Docker image for proper localization.
- Set environment variables LANG, LC_ALL, and LANGUAGE to Spanish in the backend container and ECS task definition.
- Introduced DEFAULT_LANGUAGE configuration set to "es" in backend secrets and application config to specify Spanish as the default language.
- Updated README to reflect the default language configuration and improved formatting.